### PR TITLE
feat: add ipfs.noormohammed.tech

### DIFF
--- a/gateways.json
+++ b/gateways.json
@@ -78,5 +78,6 @@
 	"http://natoboram.mynetgear.com:8080/ipfs/:hash",
 	"https://ipfs.foxgirl.dev/ipfs/:hash",
 	"https://video.oneloveipfs.com/ipfs/:hash",
-	"http://ipfs.anonymize.com/ipfs/:hash"
+	"http://ipfs.anonymize.com/ipfs/:hash",
+	"https://ipfs.noormohammed.tech/ipfs/:hash"
 ]


### PR DESCRIPTION
server is located in Mumbai India, its a ubuntu 20.04 server, **ipfs.noormohammed.tech** is proxyed by **cloudflare** free tier.
network bandwidth is Download: 103.57 Mbit/s, Upload: 0.85 Mbit/s
bandwidth is checked by `curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python -`